### PR TITLE
fix undeclared name: HumanDecodercompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ func main() {
     }
 
     // initialize a human decoder
-    humanDecoder := HumanDecoder{}
+    humanDecoder := teltonikaparser.HumanDecoder{}
 
     // loop over raw data
     for _, val := range parsedData.Data {


### PR DESCRIPTION
properly reference when use teltonikaparser as a imported library